### PR TITLE
set comments and commentstring

### DIFF
--- a/ftplugin/carbon.vim
+++ b/ftplugin/carbon.vim
@@ -1,0 +1,6 @@
+" Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+" Exceptions. See /LICENSE for license information.
+" SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+setlocal commentstring=//\ %s
+setlocal comments=://


### PR DESCRIPTION
These variables are documented e.g. [here](https://vimhelp.org/options.txt.html#%27comments%27).

For comparison other language plugins also set these two variables [vim-go](https://github.com/fatih/vim-go/blob/master/ftplugin/go.vim#L22) or [vim-toml](https://github.com/cespare/vim-toml/blob/main/ftplugin/toml.vim#L18).

I used these variables through the [tcomment](https://github.com/tomtom/tcomment_vim) plugin. e.g. `gcc` toggles whether the current line is commented in or out. Also standard vim folding (mark a section and hit `zf` appears affected by these settings).